### PR TITLE
Publish code as a binary to GPR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 14
+          registry-url: https://npm.pkg.github.com
 
       - name: Set up cache
         uses: actions/cache@v3
@@ -33,11 +34,7 @@ jobs:
         run: yarn build
 
       - name: Create archive
-        run: yarn zip
+        run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
 
-      - name: Add build to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ github.token }}
-          file: blackbox.zip
-          tag: ${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 dist/
 blackbox.js
 build
-blackbox.zip
+*tgz

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
-  "name": "blackbox",
+  "name": "@cloud-lada/blackbox",
   "version": "0.1.0",
-  "main": "src/main.ts",
+  "main": "blackbox.js",
+  "license": "Apache-2.0",
+  "author": "cloud-lada",
+  "description": "The in-vehicle components of the cloud-lada platform",
+  "bin": {
+    "blackbox": "blackbox.js"
+  },
   "scripts": {
     "build": "./scripts/build.sh",
     "lint": "eslint src/*",
-    "execute": "yarn build && node blackbox.js",
-    "zip": "zip -r blackbox.zip build/* blackbox.js"
+    "execute": "yarn build && node blackbox.js"
   },
   "devDependencies": {
     "@types/webpack-env": "^1.17.0",
@@ -24,5 +29,9 @@
     "@types/rpio": "^2.4.2",
     "commander": "^9.3.0",
     "rpio": "^2.4.2"
-  }
+  },
+  "files": [
+    "blackbox.js",
+    "build/rpio.node"
+  ]
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,5 +6,6 @@ rm -f blackbox.js
 rm -rf build
 
 esbuild src/main.ts --bundle --outfile=blackbox.js --platform=node --minify --analyze
+chmod +x blackbox.js
 mkdir -p build
 cp node_modules/rpio/build/Release/rpio.node build/rpio.node

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { Command } from "commander";
 import { version } from "../package.json";
 import { run } from "@/command";


### PR DESCRIPTION
This commit is the first attempt to update the CI workflow to use github
packages for the distribution of the CLI. In theory, we can then just
do `yarn global install` etc and run `blackbox` right off the bat.

Signed-off-by: David Bond <davidsbond93@gmail.com>